### PR TITLE
MFXComboBox bug fixes

### DIFF
--- a/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXComboBoxSkin.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXComboBoxSkin.java
@@ -124,11 +124,11 @@ public class MFXComboBoxSkin<T> extends SkinBase<MFXComboBox<T>> {
 
         comboBox.addEventHandler(MouseEvent.MOUSE_PRESSED, event -> {
             comboBox.requestFocus();
-            // stop icon pressed event from propagating to here
+
             if(event.getTarget().equals(icon.getIcon())) {
                 return;
             }
-            if (event.getClickCount() >= 2 && event.getClickCount()%2==0) {
+            if (event.getClickCount() >= 2 && event.getClickCount() % 2 == 0) {
                 NodeUtils.fireDummyEvent(icon);
             }
         });

--- a/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXComboBoxSkin.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXComboBoxSkin.java
@@ -125,7 +125,7 @@ public class MFXComboBoxSkin<T> extends SkinBase<MFXComboBox<T>> {
         comboBox.addEventHandler(MouseEvent.MOUSE_PRESSED, event -> {
             comboBox.requestFocus();
 
-            if (event.getClickCount() >= 2) {
+            if (event.getClickCount() >= 2 && event.getClickCount()%2==0) {
                 NodeUtils.fireDummyEvent(icon);
             }
         });

--- a/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXComboBoxSkin.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXComboBoxSkin.java
@@ -124,7 +124,10 @@ public class MFXComboBoxSkin<T> extends SkinBase<MFXComboBox<T>> {
 
         comboBox.addEventHandler(MouseEvent.MOUSE_PRESSED, event -> {
             comboBox.requestFocus();
-
+            // stop icon pressed event from propagating to here
+            if(event.getTarget().equals(icon.getIcon())) {
+                return;
+            }
             if (event.getClickCount() >= 2 && event.getClickCount()%2==0) {
                 NodeUtils.fireDummyEvent(icon);
             }


### PR DESCRIPTION
## Bugs Fixed: ##
1. MFXComboBox sometimes triggering (opening/closing) in 1 click instead of 2.
2. Repeated clicks on arrow to break the behavior of opening/closing.

## MFXComboBox sometimes triggering (opening/closing) in 1 click instead of 2. ##

MFXComboBox can be triggered(opened/closed) by only one click after shortly being opened/closed.

### Steps to reproduce ###

Open the ComboBox using a double click then then click once and the combo will close.

### Problem in this ###
This inconsistency can lead for unintended behavior in this situation as the user may want to close the ComboBox and thus will initiate a double click but the ComboBox will close and reopen instead of simply closing.

### Preview ###


https://user-images.githubusercontent.com/61707078/110019087-b431d900-7d30-11eb-9197-259c9215fca2.mp4

### Fix ### 
old code:   `if (event.getClickCount() >= 2) `
new code: `if (event.getClickCount() >= 2 && event.getClickCount()%2==0)`

To mitigate this, I added a %2 check to only trigger based on a double click.

---

## Repeated clicks on arrow to break the behavior of opening/closing. ##

When clicking the arrow repeatedly, the functionality will be broken due to the event also triggering the double click logic.

### Steps to reproduce ###

run demo and repeatedly click on the arrow, the combobox will remain open and refuse close due to the double click function reversing the decision.

### Preview ###


https://user-images.githubusercontent.com/61707078/110019522-3f12d380-7d31-11eb-83c5-4b0973472146.mp4



### Fix ### 
Added    
`if(event.getTarget().equals(icon.getIcon())) {
                return;
            } `

This will stop the click event on the arrow from triggering the double click logic
