### PR TITLE
MFXRectangleToggleNode graphic fix

### DIFF
--- a/materialfx/src/main/java/io/github/palexdev/materialfx/controls/MFXLabel.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/controls/MFXLabel.java
@@ -60,6 +60,7 @@ public class MFXLabel extends Control {
     private final ObjectProperty<Pos> labelAlignment = new SimpleObjectProperty<>(Pos.CENTER);
     private final ObjectProperty<Node> leadingIcon = new SimpleObjectProperty<>();
     private final ObjectProperty<Node> trailingIcon = new SimpleObjectProperty<>();
+    private final ObjectProperty<Node> graphic = new SimpleObjectProperty<>();
 
     private final ObjectProperty<Pos> alignment = new SimpleObjectProperty<>(Pos.CENTER);
 
@@ -212,6 +213,22 @@ public class MFXLabel extends Control {
 
     public void setAlignment(Pos alignment) {
         this.alignment.set(alignment);
+    }
+
+
+    public Node getGraphic() {
+        return graphic.get();
+    }
+
+    /**
+     * the graphic of the label
+     */
+    public ObjectProperty<Node> graphicProperty() {
+        return graphic;
+    }
+
+    public void setGraphic(Node node) {
+        graphic.set(node);
     }
 
     public boolean isEditorFocused() {

--- a/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXLabelSkin.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXLabelSkin.java
@@ -20,7 +20,7 @@ package io.github.palexdev.materialfx.skins;
 
 import io.github.palexdev.materialfx.controls.MFXLabel;
 import io.github.palexdev.materialfx.controls.MFXTextField;
-import io.github.palexdev.materialfx.controls.enums.Styles;
+import io.github.palexdev.materialfx.controls.enums.Styles.LabelStyles;
 import io.github.palexdev.materialfx.controls.factories.MFXAnimationFactory;
 import io.github.palexdev.materialfx.utils.LabelUtils;
 import javafx.animation.ScaleTransition;
@@ -62,7 +62,7 @@ public class MFXLabelSkin extends SkinBase<MFXLabel> {
     //================================================================================
     private final HBox container;
     private final Label textNode;
-    private boolean promptIsUsed = false;
+    private boolean promptIsUsed;
 
     private final Line unfocusedLine;
     private final Line focusedLine;
@@ -128,7 +128,7 @@ public class MFXLabelSkin extends SkinBase<MFXLabel> {
             label.getTrailingIcon().addEventFilter(MouseEvent.MOUSE_PRESSED, iconEditorHandler);
         }
 
-        if (label.getLabelStyle() != Styles.LabelStyles.STYLE2) {
+        if (label.getLabelStyle() != LabelStyles.STYLE2) {
             getChildren().addAll(container, unfocusedLine, focusedLine);
         } else {
             getChildren().add(container);
@@ -150,7 +150,7 @@ public class MFXLabelSkin extends SkinBase<MFXLabel> {
         MFXLabel label = getSkinnable();
 
         label.labelStyleProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue == Styles.LabelStyles.STYLE2) {
+            if (newValue == LabelStyles.STYLE2) {
                 getChildren().removeAll(unfocusedLine, focusedLine);
             } else if (!getChildren().contains(focusedLine)) {
                 getChildren().addAll(unfocusedLine, focusedLine);
@@ -311,9 +311,9 @@ public class MFXLabelSkin extends SkinBase<MFXLabel> {
         double editorWidth = containerWidth -
                 (
                         label.getContainerPadding().getLeft() +
-                                leadingWidth + label.getGraphicTextGap() +
-                                trailingWidth + label.getGraphicTextGap() +
-                                label.getContainerPadding().getRight()
+                        leadingWidth + label.getGraphicTextGap() +
+                        trailingWidth + label.getGraphicTextGap() +
+                        label.getContainerPadding().getRight()
                 );
         textNode.setPrefWidth(editorWidth);
         textField.resizeRelocate(posX, 0, editorWidth, containerHeight);

--- a/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXLabelSkin.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXLabelSkin.java
@@ -112,6 +112,7 @@ public class MFXLabelSkin extends SkinBase<MFXLabel> {
         textNode.fontProperty().bind(label.fontProperty());
         textNode.textFillProperty().bind(label.textFillProperty());
         textNode.alignmentProperty().bind(label.labelAlignmentProperty());
+        textNode.graphicProperty().bind(label.graphicProperty());
 
         container = new HBox(textNode);
         container.alignmentProperty().bind(label.alignmentProperty());
@@ -310,9 +311,9 @@ public class MFXLabelSkin extends SkinBase<MFXLabel> {
         double editorWidth = containerWidth -
                 (
                         label.getContainerPadding().getLeft() +
-                        leadingWidth + label.getGraphicTextGap() +
-                        trailingWidth + label.getGraphicTextGap() +
-                        label.getContainerPadding().getRight()
+                                leadingWidth + label.getGraphicTextGap() +
+                                trailingWidth + label.getGraphicTextGap() +
+                                label.getContainerPadding().getRight()
                 );
         textNode.setPrefWidth(editorWidth);
         textField.resizeRelocate(posX, 0, editorWidth, containerHeight);

--- a/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXLabelSkin.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXLabelSkin.java
@@ -20,7 +20,7 @@ package io.github.palexdev.materialfx.skins;
 
 import io.github.palexdev.materialfx.controls.MFXLabel;
 import io.github.palexdev.materialfx.controls.MFXTextField;
-import io.github.palexdev.materialfx.controls.enums.Styles.LabelStyles;
+import io.github.palexdev.materialfx.controls.enums.Styles;
 import io.github.palexdev.materialfx.controls.factories.MFXAnimationFactory;
 import io.github.palexdev.materialfx.utils.LabelUtils;
 import javafx.animation.ScaleTransition;
@@ -62,7 +62,7 @@ public class MFXLabelSkin extends SkinBase<MFXLabel> {
     //================================================================================
     private final HBox container;
     private final Label textNode;
-    private boolean promptIsUsed;
+    private boolean promptIsUsed = false;
 
     private final Line unfocusedLine;
     private final Line focusedLine;
@@ -128,7 +128,7 @@ public class MFXLabelSkin extends SkinBase<MFXLabel> {
             label.getTrailingIcon().addEventFilter(MouseEvent.MOUSE_PRESSED, iconEditorHandler);
         }
 
-        if (label.getLabelStyle() != LabelStyles.STYLE2) {
+        if (label.getLabelStyle() != Styles.LabelStyles.STYLE2) {
             getChildren().addAll(container, unfocusedLine, focusedLine);
         } else {
             getChildren().add(container);
@@ -150,7 +150,7 @@ public class MFXLabelSkin extends SkinBase<MFXLabel> {
         MFXLabel label = getSkinnable();
 
         label.labelStyleProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue == LabelStyles.STYLE2) {
+            if (newValue == Styles.LabelStyles.STYLE2) {
                 getChildren().removeAll(unfocusedLine, focusedLine);
             } else if (!getChildren().contains(focusedLine)) {
                 getChildren().addAll(unfocusedLine, focusedLine);

--- a/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXRectangleToggleNodeSkin.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXRectangleToggleNodeSkin.java
@@ -55,6 +55,7 @@ public class MFXRectangleToggleNodeSkin extends SkinBase<MFXRectangleToggleNode>
         label = new MFXLabel();
         label.setId("textNode");
         label.textProperty().bind(toggleNode.textProperty());
+        label.graphicProperty().bind(toggleNode.graphicProperty());
         label.graphicTextGapProperty().bind(toggleNode.labelTextGapProperty());
         label.getStylesheets().setAll(toggleNode.getUserAgentStylesheet());
         label.setLeadingIcon(toggleNode.getLabelLeadingIcon());


### PR DESCRIPTION
This PR "forwards" the graphic property of a MFXRectangleToggleNode to the label inside the used MfxLabel. this allows setting only the graphic of the toggleNode and it shows up centrally