### PR TITLE
Fix compiler error in MFXCheckboxSkin

### DIFF
--- a/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXCheckboxSkin.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/skins/MFXCheckboxSkin.java
@@ -144,12 +144,10 @@ public class MFXCheckboxSkin extends SkinBase<MFXCheckbox> {
          * then the center of the ripple is set to the width and/or height of container
          */
         checkBox.addEventFilter(MouseEvent.MOUSE_CLICKED, event -> {
-            if (!event, checkBox)) {
-                return;
+            if (!NodeUtils.inHierarchy(event.getPickResult().getIntersectedNode(), checkBox)) {
+                rippleGenerator.generateRipple(event);
+                checkBox.fire();
             }
-
-            rippleGenerator.generateRipple(event);
-            checkBox.fire();
         });
 
         /*


### PR DESCRIPTION
I noticed a compiler error in `MFXCheckboxSkin` in the staging branch when building, so I fixed it with code from the current 11.12.0 release.