### PR TITLE
Remove OpenJFX dependencies while publishing to mvncentral

### DIFF
--- a/materialfx/build.gradle
+++ b/materialfx/build.gradle
@@ -80,4 +80,18 @@ task removeBnd(type: Delete) {
     }
 }
 
+publishing {
+    publications {
+        main(MavenPublication) {
+            pom.withXml {
+                asNode().dependencies.'*'.findAll {
+                    it.groupId.text() == 'org.openjfx'
+                }.each {
+                    it.parent().remove(it)
+                }
+            }
+        }
+    }
+}
+
 build.dependsOn copyJar, removeBnd


### PR DESCRIPTION
Currently when you add the project as a dependency to any maven project, you get the following IDE error:

![image](https://user-images.githubusercontent.com/25760501/139809363-d8a3e29d-00a3-4533-8b13-973cf0d3df19.png)

This is happening because the dependency MaterialFX is providing javafx dependencies, that should not be happening. Hence a workaround I am using is to add the following exclusions in my `pom.xml`:

```XML
<dependency>
  <groupId>io.github.palexdev</groupId>
  <artifactId>materialfx</artifactId>
  <version>${materialfx.version}</version>
  <exclusions>
    <exclusion>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-graphics</artifactId>
    </exclusion>
    <exclusion>
      <groupId>org.openjfx</groupId>
      <artifactId>javafx-controls</artifactId>
    </exclusion>
    <exclusion>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-base</artifactId>
    </exclusion>
    <exclusion>
      <groupId>org.openjfx</groupId>
      <artifactId>javafx-swing</artifactId>
    </exclusion>
  </exclusions>
</dependency>
```

This PR removes the OpenJFX dependencies before publishing, hence solving the issue.
