### PR TITLE
Remove OpenJFX dependencies while publishing to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ subprojects {
     javafx {
         version = "17.0.2"
         modules = ['javafx.controls', 'javafx.fxml', 'javafx.media', 'javafx.swing', 'javafx.web']
+        configuration = "compileOnly"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ subprojects {
     javafx {
         version = "17.0.2"
         modules = ['javafx.controls', 'javafx.fxml', 'javafx.media', 'javafx.swing', 'javafx.web']
-        configuration = "compileOnly"
     }
 }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 
     implementation name: 'scenicview'
-    implementation "fr.brouillard.oss:cssfx:11.4.0"
+    implementation("fr.brouillard.oss:cssfx:11.4.0") { exclude group: 'org.openjfx' }
     implementation 'org.kordamp.ikonli:ikonli-core:12.2.0'
     implementation 'org.kordamp.ikonli:ikonli-javafx:12.2.0'
     implementation 'org.kordamp.ikonli:ikonli-fontawesome5-pack:12.2.0'

--- a/materialfx/build.gradle
+++ b/materialfx/build.gradle
@@ -26,6 +26,10 @@ dependencies {
     implementation 'io.github.palexdev:virtualizedfx:11.2.5'
 }
 
+javafx {
+    configuration = "compileOnly"
+}
+
 javadoc {
     excludes = ['**/*.html', 'META-INF/**']
 


### PR DESCRIPTION
Adding this configuration removes the transitive dependency on OpenJFX.