### PR TITLE
Dependency on VirtualizedFX in POM should in the 'compile' scope

### DIFF
--- a/materialfx/build.gradle
+++ b/materialfx/build.gradle
@@ -1,6 +1,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
+    id 'java-library'
     id 'biz.aQute.bnd.builder' version '6.2.0'
     id 'com.vanniktech.maven.publish' version '0.19.0'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
@@ -22,7 +23,7 @@ compileJava {
 dependencies {
     testImplementation('junit:junit:4.13.2')
 
-    implementation 'io.github.palexdev:virtualizedfx:11.2.6'
+    api 'io.github.palexdev:virtualizedfx:11.2.6'
 }
 
 javafx {


### PR DESCRIPTION
Currently, the dependency on VirtualizedFX in the POM is as follows:
```xml
<dependency>
  <groupId>io.github.palexdev</groupId>
  <artifactId>virtualizedfx</artifactId>
  <version>11.2.6</version>
  <scope>runtime</scope>
</dependency>
```

Since this is the **runtime** scoped, programs that depend on MaterialFX are compiled without place VirtualizedFX in the classpath. At some point, this causes the program to fail to compile.

For example, when I using the `MFXListCell`, the compilation fails.

```
/***/UserListView.java:32: error: cannot access Cell
    private final class UserCell extends MFXListCell<User> {
                  ^
  class file for io.github.palexdev.virtualizedfx.cell.Cell not found
/***/UserListView.java:11: error: cannot access SimpleVirtualFlow
public class UserListView extends MFXListView<User> {
       ^
  class file for io.github.palexdev.virtualizedfx.flow.simple.SimpleVirtualFlow not found
2 errors
```

This PR fixes the problem in the POM.