### PR TITLE
doc: fix nested link in javadoc

### DIFF
--- a/materialfx/src/main/java/io/github/palexdev/materialfx/controls/models/spinner/SpinnerModel.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/controls/models/spinner/SpinnerModel.java
@@ -27,7 +27,7 @@ import javafx.util.StringConverter;
  * <p>
  * {@code SpinnerModel} is basically an helper class to allow the spinner to work on any object
  * type as long as a model exists for it. The model is responsible for changing the spinner's value by
- * going forward or backwards ({@link #next() or {@link #previous()}}.
+ * going forward or backwards ({@link #next()} or {@link #previous()}).
  * <p>
  * Along this core functionality the model also specifies a {@link StringConverter} which will be
  * used to convert the T value to a String, which will be the spinner's text.


### PR DESCRIPTION
Resolves a warning during `gradlew build`.