### PR TITLE
Fixfor#227

### DIFF
--- a/materialfx/src/main/java/io/github/palexdev/materialfx/dialogs/MFXStageDialog.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/dialogs/MFXStageDialog.java
@@ -116,7 +116,7 @@ public class MFXStageDialog extends Stage {
         // WindowEvent.WINDOW_SHOWING
         //
 
-        private final ChangeListener<Number> widthChangelistener = new ChangeListener<>() {
+        private final ChangeListener<Number> widthChangeListener = new ChangeListener<>() {
                 @Override
                 public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
                         if (centerInOwnerNode.getValue()) {
@@ -125,7 +125,7 @@ public class MFXStageDialog extends Stage {
                 }
         };
 
-        private final ChangeListener<Number> heightChangelistener = new ChangeListener<>() {
+        private final ChangeListener<Number> heightChangeListener = new ChangeListener<>() {
                 @Override
                 public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue) {
                         if (centerInOwnerNode.getValue()) {
@@ -166,8 +166,8 @@ public class MFXStageDialog extends Stage {
 			if (oldValue != null) {
 				oldValue.removeEventHandler(MouseEvent.MOUSE_PRESSED, mousePressed);
 				oldValue.removeEventHandler(MouseEvent.MOUSE_DRAGGED, mouseDragged);
-                                oldValue.widthProperty().removeListener(widthChangelistener);
-                                oldValue.widthProperty().removeListener(heightChangelistener);
+                                oldValue.widthProperty().removeListener(widthChangeListener);
+                                oldValue.heightProperty().removeListener(heightChangeListener);
 			}
 
 			setScene(buildScene(getContent()));
@@ -190,8 +190,8 @@ public class MFXStageDialog extends Stage {
 	 * for the given content.
 	 */
 	protected Scene buildScene(AbstractMFXDialog content) {
-                widthProperty().addListener(widthChangelistener);
-                heightProperty().addListener(heightChangelistener);
+                widthProperty().addListener(widthChangeListener);
+                heightProperty().addListener(heightChangeListener);
 
 		Scene scene = new Scene(content);
 		scene.setFill(Color.TRANSPARENT);


### PR DESCRIPTION
related to PR #301 (sorry if there is a way to update a PR, I am not very familiar with the flow ... :( )

I took into account all comments. Regarding https://github.com/palexdev/MaterialFX/pull/301#discussion_r1141344615, I think I found an elegant solution that takes into account changes in content and when content is null.
Please note the demo seems not triggering the listener set in [line contentProperty().addListener(](https://github.com/stefanofornari/MaterialFX/blob/1382041e3db92991b036ebfeb3575f104279a4bb/materialfx/src/main/java/io/github/palexdev/materialfx/dialogs/MFXStageDialog.java#L165) and I don't have a unit test to test it.

I tested with the demo app and it works.