### PR TITLE
Fix invalid change range when interacting with a ComboBox

### DIFF
--- a/materialfx/src/main/java/io/github/palexdev/materialfx/utils/ListChangeHelper.java
+++ b/materialfx/src/main/java/io/github/palexdev/materialfx/utils/ListChangeHelper.java
@@ -39,7 +39,7 @@ public class ListChangeHelper {
                 IntegerRange range = IntegerRange.of(change.getFrom(), change.getTo() - 1);
                 Set<Integer> changed = IntegerRange.expandRangeToSet(range).stream().filter(i -> IntegerRange.inRangeOf(i, indexes)).collect(Collectors.toSet());
 
-                removeFrom = change.getTo();
+                removeFrom = change.getFrom();
                 removeTo = NumberUtils.clamp(change.getRemovedSize() - 1, 0, indexes.getMax());
                 removedAccumulator.addAll(IntegerRange.expandRangeToSet(IntegerRange.of(removeFrom, removeTo)));
 


### PR DESCRIPTION
I was configuring filters on a MFXTableView. Testing them I noticed that every time I chose a different field the following exception would be thrown:

```
Exception in thread "JavaFX Application Thread" java.lang.IllegalArgumentException: Invalid range for values: Min[11], Max[10]
	at mfx.core/io.github.palexdev.mfxcore.base.beans.range.NumberRange.<init>(NumberRange.java:40)
	at mfx.core/io.github.palexdev.mfxcore.base.beans.range.IntegerRange.<init>(IntegerRange.java:33)
	at mfx.core/io.github.palexdev.mfxcore.base.beans.range.IntegerRange.of(IntegerRange.java:44)
	at MaterialFX@11.17.0/io.github.palexdev.materialfx.utils.ListChangeHelper.processChange(ListChangeHelper.java:44)
	at MaterialFX@11.17.0/io.github.palexdev.materialfx.controls.MFXComboBox.itemsChanged(MFXComboBox.java:25
        ...
```

Anyways, I went to where the exception is being thrown, and saw the following lines:
 ```java
removeFrom = change.getTo();
removeTo = NumberUtils.clamp(change.getRemovedSize() - 1, 0, indexes.getMax());
removedAccumulator.addAll(IntegerRange.expandRangeToSet(IntegerRange.of(removeFrom, removeTo)));
```
`removeFrom` is set to where the change ends? Is that right?

So I changed the `#getTo()` to a `#getFrom` and now the exception is nowhere to be seen.

I would love any feedback on this, I don't even know if I fixed the problem or broke the code while trying to do so.